### PR TITLE
Added optional binding to prevent nil crashes

### DIFF
--- a/AKGPushAnimatorDemo/AKGPushAnimator/AKGInteractionAnimator.swift
+++ b/AKGPushAnimatorDemo/AKGPushAnimator/AKGInteractionAnimator.swift
@@ -26,7 +26,7 @@ class AKGInteractionAnimator: UIPercentDrivenInteractiveTransition {
     }
     
     func handlePanGesture(_ gestureRecognizer: UIPanGestureRecognizer) {
-        let viewTranslation = gestureRecognizer.translation(in: gestureRecognizer.view!.superview!)
+        let viewTranslation = gestureRecognizer.translation(in: gestureRecognizer.view?.superview)
         let velocity : CGPoint = gestureRecognizer.velocity(in: gestureRecognizer.view)
         
         switch gestureRecognizer.state {

--- a/AKGPushAnimatorDemo/AKGPushAnimator/AKGPushAnimator.swift
+++ b/AKGPushAnimatorDemo/AKGPushAnimator/AKGPushAnimator.swift
@@ -71,10 +71,11 @@ class AKGPushAnimator: NSObject, UIViewControllerAnimatedTransitioning {
     func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
         
         let containerView = transitionContext.containerView
-        let toVC = transitionContext.viewController(forKey: .to)!
-        let fromVC = transitionContext.viewController(forKey: .from)!
-        let toView = toVC.view!
-        let fromView = fromVC.view!
+        
+        guard let toVC = transitionContext.viewController(forKey: .to),
+            let fromVC = transitionContext.viewController(forKey: .from),
+            let toView = toVC.view,
+            let fromView = fromVC.view else { return }
         
         if !isReverseTransition {
             
@@ -123,8 +124,8 @@ class AKGPushAnimator: NSObject, UIViewControllerAnimatedTransitioning {
 }
 
 private func animate(withTransitionContext transitionContext:UIViewControllerContextTransitioning,
-                     toView: UIView!,
-                     fromView: UIView!,
+                     toView: UIView,
+                     fromView: UIView,
                      duration: TimeInterval,
                      delay: TimeInterval,
                      options: UIViewAnimationOptions = [],


### PR DESCRIPTION
Forced unwrapping is discouraged in general, so I added optional binding to make it fail-safe, more Swifty way.